### PR TITLE
turn off ternary-no-unreachable-rule, bump versions

### DIFF
--- a/eslint-config-internal/index.js
+++ b/eslint-config-internal/index.js
@@ -60,6 +60,7 @@ module.exports = {
       'newlines-between': 'ignore',
     }],
     "multiline-ternary": ["error", "always"],
+    "ternary/no-unreachable": "off",
 
     // typescript
     "@typescript-eslint/explicit-function-return-type": "off",

--- a/eslint-config-internal/package.json
+++ b/eslint-config-internal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mate-academy/eslint-config-internal",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "description": "Eslint config for Mate academy developers based on airbnb with Typescript",
   "main": "index.js",
   "scripts": {

--- a/eslint-config-react-internal/package.json
+++ b/eslint-config-react-internal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mate-academy/eslint-config-react-internal",
-  "version": "0.0.18",
+  "version": "0.0.19",
   "description": "React eslint config for internal development",
   "main": "index.js",
   "scripts": {
@@ -9,7 +9,7 @@
   "author": "Mate academy",
   "license": "ISC",
   "dependencies": {
-    "@mate-academy/eslint-config-internal": "0.0.14",
+    "@mate-academy/eslint-config-internal": "0.0.15",
     "eslint-config-airbnb": "^18.2.0",
     "eslint-plugin-jsx-a11y": "^6.3.1",
     "eslint-plugin-react": "^7.20.5",


### PR DESCRIPTION
Turned off broken ternary/no-unreachable rule in eslint-plugin-ternary
Bumped eslint-config-internal to v0.0.15
Bumped eslint-config-react-internal to v0.0.19