### PR TITLE
[Student eslint]: Add rule to ignore template strings

### DIFF
--- a/eslint-config/index.js
+++ b/eslint-config/index.js
@@ -14,7 +14,8 @@ module.exports = {
   "rules": {
     "max-len": ["error", {
       "code": 80,
-      "comments": 80
+      "comments": 80,
+      "ignoreTemplateLiterals": true,
     }],
     "semi": ["error", "always"],
     "semi-style": ["error", "last"],


### PR DESCRIPTION
## Summary

Added `ignoreTemplateLiterals: true` to eslint `max-len` rule